### PR TITLE
Add dependency on semigroups

### DIFF
--- a/separated-values.cabal
+++ b/separated-values.cabal
@@ -33,6 +33,7 @@ library
                        , charset >=0.3 && <=0.4
                        , parsers >=0.12 && <0.13
                        , semigroupoids >= 5 && <6
+                       , semigroups >= 0.8 && <1
   hs-source-dirs:      src
   default-language:    Haskell2010
   ghc-options:

--- a/separated-values.nix
+++ b/separated-values.nix
@@ -1,11 +1,11 @@
-{ mkDerivation, base, charset, parsec, parsers, semigroupoids
+{ mkDerivation, base, charset, parsec, parsers, semigroupoids, semigroups
 , stdenv, tasty, tasty-discover, tasty-hunit, tasty-quickcheck
 }:
 mkDerivation {
   pname = "separated-values";
   version = "0.1.0.0";
   src = ./.;
-  libraryHaskellDepends = [ base charset parsers semigroupoids ];
+  libraryHaskellDepends = [ base charset parsers semigroupoids semigroups ];
   testHaskellDepends = [
     base parsec parsers tasty tasty-discover tasty-hunit
     tasty-quickcheck


### PR DESCRIPTION
Semigroups were not in base until GHC 8.0, so we add an explicit dependency
on semigropus in order to build on 7.10.2.

@dalaing Have I made the right changes to the .nix file? Should I change any of the other .nix files?